### PR TITLE
Medical Domain Dataset Support (medical r1 v1.0)

### DIFF
--- a/recipes/examples/medical_zero_3B_config.yaml
+++ b/recipes/examples/medical_zero_3B_config.yaml
@@ -1,0 +1,62 @@
+# This is X-R1(https://github.com/dhcode-cpp/X-R1) project training config:
+# required >=  4x3090(24G)/4090(24G)
+# running time ~1h
+
+
+# ```shell
+# ACCELERATE_LOG_LEVEL=info \
+# accelerate launch \
+# --config_file recipes/zero3.yaml \
+# --num_processes=2 \
+# src/x_r1/grpo.py \
+# --config recipes/examples/medical_zero_3B_config.yaml \
+# > ./output/mathcn_3B_sampling.log 2>&1
+# ```
+
+
+# Model arguments
+model_name_or_path: Qwen/Qwen2.5-3B
+model_revision: main
+torch_dtype: bfloat16
+attn_implementation: flash_attention_2
+
+# Data training arguments
+dataset_name: FreedomIntelligence/medical-o1-verifiable-problem
+dataset_configs:
+- train
+num_processes: 3
+
+# GRPO trainer config
+bf16: true
+use_vllm: true
+vllm_device: auto
+vllm_gpu_memory_utilization: 0.7
+do_eval: no
+eval_strategy: "no"
+eval_steps: 10
+gradient_accumulation_steps: 4
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+hub_model_id: Qwen/Qwen2.5-3B
+hub_strategy: every_save
+learning_rate: 3.0e-06
+log_level: info
+logging_steps: 10
+logging_strategy: steps
+lr_scheduler_type: cosine
+max_prompt_length: 256
+num_generations: 4
+max_completion_length: 1024
+max_steps: -1
+num_train_epochs: 2
+output_dir: output/X-R1-Qwen2.5-3B-Instruct-cn-medical
+overwrite_output_dir: true
+per_device_eval_batch_size: 1
+per_device_train_batch_size: 1
+push_to_hub: False
+report_to:
+- wandb
+save_strategy: "epoch"
+seed: 42
+warmup_ratio: 0.1

--- a/src/x_r1/grpo.py
+++ b/src/x_r1/grpo.py
@@ -146,6 +146,13 @@ def main(script_args, training_args, model_args):
     # Load the dataset
     dataset = load_dataset(script_args.dataset_name, name=script_args.dataset_config)
 
+    # align the dataset
+    if script_args.dataset_name == "FreedomIntelligence/medical-o1-verifiable-problem":
+        dataset = dataset.rename_columns({
+            "Open-ended Verifiable Question": "problem",
+            "Ground-True Answer": "solution"
+        })
+
     # Get reward functions
     REWARD_FUNCS_REGISTRY = {
         "accuracy": accuracy_reward,


### PR DESCRIPTION
# Medical Domain Dataset Support (v1.0)

**Note: The model's reward improvement is not significant yet, still working on code optimization.**

## Overview

Added support for medical domain dataset training with GPT-4o-mini as the answer verification judge.

## Dataset

Using `FreedomIntelligence/medical-o1-verifiable-problem` for training.

## Key Changes

- Implemented answer verification using GPT-4o-mini as judge
- Enhanced medical domain Q&A verification process
- Added medical dataset configuration

## Usage

1. Configure OpenAI settings in `rewards.py`:

```python
client = OpenAI(
    api_key="your_api_key_here",
    base_url="your_base_url_here"
)
```

2. Run the training with:

```cmd
ACCELERATE_LOG_LEVEL=info \
accelerate launch \
--config_file recipes/zero3.yaml \
--num_processes=3 \
src/x_r1/grpo.py \
--config recipes/examples/medical_zero_3B_config.yaml \
> ./output/mathcn_3B_sampling.log 2>&1
```

## Results
![681fdc9688395a78434def3d845e47b](https://github.com/user-attachments/assets/53b5fbf4-c1c5-462f-994d-aa5fe437977c)



