### PR TITLE
fix_ref_model

### DIFF
--- a/src/x_r1/x_grpo_trainer.py
+++ b/src/x_r1/x_grpo_trainer.py
@@ -152,7 +152,6 @@ class XGRPOTrainer(GRPOTrainer):
             # If PEFT is used, the reference model is not needed since the adapter can be disabled
             # to revert to the initial model.
             self.ref_model = None
-        self.ref_model = None
         
         print('ref_model', self.ref_model)
 


### PR DESCRIPTION
On the latest code of 02/18, when I fine-tuning with full parameter + zero3, the error below is obtained.
  File "/workspace/data/iauto/wjz/X-R1/src/x_r1/x_grpo_trainer.py", line 508, in _prepare_inputs
    with self.accelerator.unwrap_model(self.model).disable_adapter():

After doing some debugging, I found a bug about ref_model that caused rel_model not to load correctly.
Makes GRPOTrainer mistake the policy model for a peft model.
I fixed this problem and ran it correctly. Now submit the pr.